### PR TITLE
add entrypoint so mpd can be used outside of an interactive shell

### DIFF
--- a/ubuntu-docker/1204/Dockerfile
+++ b/ubuntu-docker/1204/Dockerfile
@@ -1,6 +1,6 @@
 from ubuntu:12.04
 
-env NMAG_VERSION 0.2.1
+env NMAG_VERSION=0.2.1
 
 run \
 	# Switch out repository references for old releases and install dependencies
@@ -30,8 +30,7 @@ run \
 	# Set up mpd
 	echo "MPD_SECRETWORD=$RANDOM" > /home/nmag/.mpd.conf && \
 	chown nmag:nmag /home/nmag/.mpd.conf && \
-	chmod 600 /home/nmag/.mpd.conf && \
-	echo "mpd &" >> /home/nmag/.bashrc
+	chmod 600 /home/nmag/.mpd.conf
 
 run \
 	# Clean up
@@ -48,5 +47,14 @@ run \
 	## set the userid manually (nmag as first added user is 1000)
 	chown -R 1000:1000 /io
 
-WORKDIR /io
-cmd su nmag
+workdir /io
+
+user nmag
+
+env USER=nmag
+
+add entrypoint.sh /home/nmag/entrypoint.sh
+
+entrypoint ["/home/nmag/entrypoint.sh"]
+
+cmd ["/bin/bash"]

--- a/ubuntu-docker/1204/Makefile
+++ b/ubuntu-docker/1204/Makefile
@@ -7,7 +7,7 @@ run:
 	docker run --rm -ti -v `pwd`:/io nmag-12.04
 
 sphere1:
-	docker run --rm -v `pwd`:/io nmag-12.04 su nmag -c "bash ~/.bashrc && sleep 1 && mpiexec -n 2 nsim sphere1.py"
+	docker run --rm -v `pwd`:/io nmag-12.04 mpiexec -n 2 nsim sphere1.py
 
 test: clean sphere1
 

--- a/ubuntu-docker/1204/entrypoint.sh
+++ b/ubuntu-docker/1204/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mpd &   # Start MPD
+sleep 1 # Wait for MPD to start
+$@      # Forward commands from input


### PR DESCRIPTION
Added entrypoint.sh so that mpiexec can be used without using the container from an interactive shell.

i.e. you can now do something like this:
```
docker run nmag mpiexec -n 4 nsim simulation.py
```

I also had to configure the user information to allow this to function properly.